### PR TITLE
feat: 상세페이지 구현 및 좋아요댓글 수정

### DIFF
--- a/frontend/static/css/post_detail.css
+++ b/frontend/static/css/post_detail.css
@@ -1,0 +1,252 @@
+/* 전체 컨테이너: 중앙 정렬 및 최대 너비 제한 */
+.detail-container {
+    max-width: 800px;
+    margin: 40px auto;
+    padding: 0 20px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+/* 상단 네비게이션 */
+.detail-nav {
+    margin-bottom: 20px;
+}
+
+.back-link {
+    text-decoration: none;
+    color: #6b7280;
+    font-size: 0.95rem;
+    transition: color 0.2s;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.back-link:hover {
+    color: #111827;
+}
+
+/* 게시글 카드 스타일 */
+.post-card {
+    background-color: #ffffff;
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    padding: 40px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+/* 게시글 헤더 */
+.post-title {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #111827;
+    margin-bottom: 24px;
+    line-height: 1.3;
+}
+
+.post-meta-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.author-info {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.author-avatar {
+    width: 40px;
+    height: 40px;
+    background-color: #f3f4f6;
+    color: #4b5563;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    font-size: 1rem;
+}
+
+.author-text {
+    display: flex;
+    flex-direction: column;
+}
+
+.author-name {
+    font-weight: 600;
+    color: #374151;
+    font-size: 0.95rem;
+}
+
+.post-date {
+    font-size: 0.85rem;
+    color: #9ca3af;
+}
+
+/* 구분선 */
+.divider {
+    border: 0;
+    border-top: 1px solid #e5e7eb;
+    margin: 24px 0;
+}
+
+/* 게시글 본문 */
+.post-content {
+    font-size: 1.05rem;
+    line-height: 1.7;
+    color: #374151;
+    min-height: 150px; /* 내용이 짧아도 최소 높이 확보 */
+    margin-bottom: 32px;
+}
+
+/* 하단 좋아요 및 기타 */
+.post-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 40px;
+}
+
+.like-btn {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    border: 1px solid #e5e7eb;
+    border-radius: 20px;
+    background: white;
+    cursor: pointer;
+    transition: all 0.2s;
+    font-size: 1rem;
+    color: #4b5563;
+}
+
+.like-btn:hover {
+    background-color: #f9fafb;
+    border-color: #d1d5db;
+}
+
+.like-btn i.fa-solid {
+    color: #ef4444; /* 빨간 하트 */
+}
+
+.view-count {
+    font-size: 0.9rem;
+    color: #9ca3af;
+}
+
+/* 댓글 섹션 */
+.comment-section {
+    margin-top: 40px;
+    max-width: 800px;
+}
+
+.comment-header {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: 20px;
+    color: #111827;
+}
+
+.comment-count {
+    color: #6b7280;
+    margin-left: 4px;
+    font-size: 1rem;
+}
+
+/* 댓글 작성 폼 */
+.comment-form-container {
+    background: #f9fafb;
+    padding: 20px;
+    border-radius: 12px;
+    margin-bottom: 30px;
+}
+
+.comment-form textarea {
+    width: 100%;
+    height: 80px;
+    padding: 12px;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    resize: none;
+    font-family: inherit;
+    margin-bottom: 10px;
+    outline: none;
+}
+
+.comment-form textarea:focus {
+    border-color: #3b82f6; /* 포커스 시 파란색 테두리 */
+}
+
+.submit-comment-btn {
+    background-color: #3b82f6; /* 첨부해주신 사진의 파란 버튼 색 */
+    color: white;
+    border: none;
+    padding: 8px 20px;
+    border-radius: 6px;
+    font-weight: 600;
+    cursor: pointer;
+    float: right;
+}
+
+.submit-comment-btn:hover {
+    background-color: #2563eb;
+}
+
+/* 댓글 목록 아이템 */
+.comment-item {
+    display: flex;
+    gap: 16px;
+    padding: 20px 0;
+    border-bottom: 1px solid #f3f4f6;
+}
+
+.comment-item:last-child {
+    border-bottom: none;
+}
+
+.comment-avatar {
+    width: 36px;
+    height: 36px;
+    background-color: #e5e7eb;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.85rem;
+    color: #4b5563;
+    flex-shrink: 0;
+}
+
+.comment-meta {
+    margin-bottom: 6px;
+}
+
+.comment-author {
+    font-weight: 600;
+    font-size: 0.95rem;
+    margin-right: 8px;
+}
+
+.comment-date {
+    font-size: 0.8rem;
+    color: #9ca3af;
+}
+
+.comment-text {
+    font-size: 0.95rem;
+    color: #374151;
+    line-height: 1.5;
+}
+
+/* 모바일 반응형 */
+@media (max-width: 640px) {
+    .post-card {
+        padding: 24px;
+    }
+    
+    .post-title {
+        font-size: 1.4rem;
+    }
+}

--- a/frontend/static/js/community.js
+++ b/frontend/static/js/community.js
@@ -1,23 +1,96 @@
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener('DOMContentLoaded', function() {
     const writeBtn = document.getElementById("write-btn");
 
-    writeBtn.addEventListener("click", async (e) => {
-        e.preventDefault(); // 기본 링크 이동 막기
+    if (writeBtn) { 
+        writeBtn.addEventListener("click", async (e) => {
+            e.preventDefault(); // 기본 링크 이동 막기
 
-        const response = await fetch("/api/check-login/", {
-            method: "GET",
-            credentials: "include", // 세션 쿠키 포함해서 요청
+            try {
+                const response = await fetch("/api/check-login/", {
+                    method: "GET",
+                    credentials: "include", // 세션 쿠키 포함해서 요청
+                });
+
+                if (!response.ok) {
+                    throw new Error('로그인 확인 중 서버 오류가 발생했습니다.');
+                }
+
+                const data = await response.json();
+
+                if (data.is_authenticated) {
+                    // 로그인 되어 있으면 글쓰기 페이지로 이동
+                    window.location.href = "/writing/";
+                } else {
+                    // 로그인 안 되어 있으면 로그인 페이지로 이동
+                    alert("글쓰기는 로그인 후 이용할 수 있습니다.");
+                    window.location.href = "/logindemo/";
+                }
+            } catch (error) {
+                console.error("Login check failed:", error);
+                alert("로그인 상태 확인 중 오류가 발생했습니다. 다시 시도해주세요.");
+            }
+        });
+    }
+
+    const likeButtons = document.querySelectorAll('.like-btn');
+
+    likeButtons.forEach(button => {
+        button.addEventListener('click', function(event) {
+            // 버튼 안에 있는 아이콘이나 숫자를 눌러도 버튼 자체가 클릭된 것으로 처리
+            const btn = event.currentTarget;
+            const postId = btn.dataset.postId; // data-post-id 값
+            
+            // handleLike 함수는 DOMContentLoaded 리스너 밖에 정의합니다.
+            handleLike(postId, btn);
+        });
+    });
+
+});
+
+
+async function handleLike(postId, btn) {
+    // API 주소
+    const url = `/community/like/${postId}/`; 
+
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': csrfToken
+            },
+            body: JSON.stringify({
+                'post_id': postId
+            })
         });
 
-        const data = await response.json();
-
-        if (data.is_authenticated) {
-            // 로그인 되어 있으면 글쓰기 페이지로 이동
-            window.location.href = "/writing/";
-        } else {
-            // 로그인 안 되어 있으면 로그인 페이지로 이동
-            alert("글쓰기는 로그인 후 이용할 수 있습니다.");
-            window.location.href = "/logindemo/";
+        if (!response.ok) {
+            throw new Error('서버 응답에 문제가 있습니다. (로그인 필요 등)');
         }
-    });
-});
+
+        // 서버로부터 JSON 응답을 받습니다.
+        // data 구조 예시: { "likes_count": 12, "is_liked": true }
+        const data = await response.json();
+        
+        const icon = btn.querySelector('i'); // 버튼 안의 아이콘
+        const countSpan = btn.querySelector('span'); // 버튼 안의 숫자
+        
+        // 숫자 업데이트
+        countSpan.innerText = data.likes_count;
+
+        // 아이콘 및 상태 업데이트
+        if (data.is_liked) {
+            btn.dataset.liked = "true";
+            icon.classList.remove('fa-regular', 'text-gray-500'); // 빈 하트 스타일 제거
+            icon.classList.add('fa-solid', 'text-red-500');       // 빨간 하트 스타일 추가
+        } else {
+            btn.dataset.liked = "false";
+            icon.classList.remove('fa-solid', 'text-red-500');     // 빨간 하트 스타일 제거
+            icon.classList.add('fa-regular', 'text-gray-500');     // 빈 하트 스타일 추가
+        }
+
+    } catch (error) {
+        console.error('Error:', error);
+        alert('좋아요 처리에 실패했습니다. 잠시 후 다시 시도해주세요.');
+    }
+}

--- a/frontend/templates/community/community.html
+++ b/frontend/templates/community/community.html
@@ -2,12 +2,16 @@
 {% load static %}
 
 {% block style %}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 <link rel="stylesheet" href="{% static 'css/community.css' %}">
 {% endblock style %}
 
 {% block script %} 
     <script src="{% static 'js/community.js' %}"></script>
-<!--사용할 js가 있다면 추가해서 쓰시면 됩니다-->
+    <!-- CSRF Token을 JS에서 쓰기 위해 숨겨진 요소로 저장 -->
+    <script>
+        const csrfToken = "{{ csrf_token }}";
+    </script>
 {% endblock script %}
 
 
@@ -54,13 +58,29 @@
                     </div>
                     <p class="topic-snippet">{{ post.snippet }}</p>
                     <div class="topic-meta">
-                    <span>
-                        <i class="fa-solid fa-thumbs-up"></i> {{ post.likes_count }}
-                    </span>
-                    <span>
-                        <i class="fa-solid fa-comment"></i> {{ post.comments_count }}
-                    </span>
-                </div>
+                        
+                        <!-- 좋아요 버튼 -->
+                        <!-- data-liked: 현재 내가 좋아요를 눌렀는지 여부를 문자열("true"/"false")로 저장 -->
+                        <button class="like-btn group flex items-center gap-1 cursor-pointer" 
+                                data-post-id="{{ post.id }}"
+                                data-liked="{% if post.is_liked %}true{% else %}false{% endif %}">
+                            
+                            <i id="like-icon-{{ post.id }}" 
+                               class="fa-heart text-lg transition-transform group-hover:scale-110 
+                               {% if post.is_liked %}fa-solid text-red-500{% else %}fa-regular text-gray-500{% endif %}">
+                            </i>
+                            
+                            <span id="like-count-{{ post.id }}" class="text-sm text-gray-600">
+                                {{ post.likes_count }}
+                            </span>
+                        </button>
+
+                        <!-- 댓글 버튼 (클릭 시 상세 페이지로 이동) -->
+                        <a href="{{ post.detail_url }}" class="comment-link flex items-center gap-1 hover:text-blue-500 ml-4">
+                            <i class="fa-regular fa-comment-dots text-lg"></i>
+                            <span class="text-sm text-gray-600">{{ post.comments_count }}</span>
+                        </a>
+                    </div>
                 </div>
             </article>
 

--- a/frontend/templates/community/post_detail.html
+++ b/frontend/templates/community/post_detail.html
@@ -1,0 +1,105 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block style %}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+<link rel="stylesheet" href="{% static 'css/post_detail.css' %}">
+{% endblock style %}
+
+{% block script %}
+    <script src="{% static 'js/community.js' %}"></script>
+    <script>
+        const csrfToken = "{{ csrf_token }}";
+    </script>
+{% endblock script %}
+
+{% block body %}
+<div class="detail-container">
+    <div class="detail-nav">
+        <!-- href에 커뮤니티 목록 URL을 넣으세요 -->
+        <a href="{% url 'frontend:community' %}" class="back-link">
+            <i class="fa-solid fa-arrow-left"></i> 목록으로 돌아가기
+        </a>
+    </div>
+
+    <article class="post-card">
+        <!-- 게시글 헤더: 제목, 작성자, 날짜 -->
+        <header class="post-header">
+            <h1 class="post-title">{{ post.title }}</h1>
+            
+            <div class="post-meta-row">
+                <div class="author-info">
+                    <div class="author-avatar">{{ post.author_initial }}</div>
+                    <div class="author-text">
+                        <span class="author-name">{{ post.author_name }}</span>
+                        <span class="post-date">{{ post.created_at|date:"Y년 m월 d일 H:i" }}</span>
+                    </div>
+                </div>
+                
+                <!-- 수정/삭제 버튼 (작성자 본인에게만 보임) -->
+                {% if request.user == post.author %}
+                <div class="post-actions">
+                    <a href="#" class="action-btn edit-btn">수정</a>
+                    <a href="#" class="action-btn delete-btn">삭제</a>
+                </div>
+                {% endif %}
+            </div>
+        </header>
+
+        <hr class="divider">
+
+        <div class="post-content">
+            <!-- linebreaks 필터: 엔터를 <br>나 <p>로 바꿔줌 -->
+            {{ post.content|linebreaks }}
+        </div>
+
+        <div class="post-footer">
+            <div class="like-wrapper">
+                <!-- 리스트 페이지와 동일한 구조의 좋아요 버튼 -->
+                <button class="like-btn" 
+                        data-post-id="{{ post.id }}"
+                        data-liked="{% if post.is_liked %}true{% else %}false{% endif %}">
+                    
+                    <i class="fa-heart {% if post.is_liked %}fa-solid text-red-500{% else %}fa-regular text-gray-500{% endif %}"></i>
+                    <span>{{ post.likes_count }}</span>
+                </button>
+            </div>
+        </div>
+    </article>
+
+    <section class="comment-section">
+        <h3 class="comment-header">댓글 <span class="comment-count">{{ post.comments_count }}</span></h3>
+
+        <div class="comment-form-container">
+            {% if user.is_authenticated %}
+            <form method="POST" action="" class="comment-form"> 
+                {% csrf_token %}
+                <textarea name="content" placeholder="댓글을 남겨주세요." required></textarea>
+                <button type="submit" class="submit-comment-btn">등록</button>
+            </form>
+            {% else %}
+            <div class="login-plz">
+                <a href="/logindemo/">로그인</a> 후 댓글을 남길 수 있습니다.
+            </div>
+            {% endif %}
+        </div>
+
+        <div class="comment-list">
+            {% for comment in comments %}
+            <div class="comment-item">
+                <div class="comment-avatar">{{ comment.author_initial }}</div>
+                <div class="comment-content-box">
+                    <div class="comment-meta">
+                        <span class="comment-author">{{ comment.author_name }}</span>
+                        <span class="comment-date">{{ comment.created_at|timesince }} 전</span>
+                    </div>
+                    <p class="comment-text">{{ comment.content|linebreaksbr }}</p>
+                </div>
+            </div>
+            {% empty %}
+            <p class="no-comments">첫 번째 댓글의 주인공이 되어보세요!</p>
+            {% endfor %}
+        </div>
+    </section>
+</div>
+{% endblock body %}

--- a/frontend/urls.py
+++ b/frontend/urls.py
@@ -7,6 +7,9 @@ app_name = "frontend"
 urlpatterns = [
     path("citizen/", views.CitizenView.as_view(), name="citizen"),
     path("community/", views.CommunityView.as_view(), name="community"),
+    # 커뮤니티 상세 페이지
+    # <int:post_id> 부분이 URL에 적힌 숫자를 받아 view.spy의 post_detail_view 함수의 post_id 인자로 념겨줌
+    path("community/<int:post_id>/", views.post_detail_view, name="post_detail"),
     path("writing/", views.WritingView.as_view(), name="writing"),
     path("emotional/", views.EmotionalView.as_view(), name="emotional"),
     path("health/", views.HealthView.as_view(), name="health"),

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -2,8 +2,47 @@ from django.views.generic import TemplateView
 import datetime     # 'timesince' 필터 및 임시 데이터 생성을 위해 임포트
 from django.shortcuts import render, redirect
         # 함수 기반 뷰(FBV) 및 리다이렉트를 위해 임포트
-
+from django.http import Http404
 from django import forms
+
+
+# [MOCK DB] 임시 데이터 저장소
+# 리스트 페이지와 상세 페이지가 이 데이터를 공유합니다.
+def get_dummy_db():
+    # 날짜 계산용
+    now = datetime.datetime.now()
+    
+    return [
+        {
+            'id': 1,  # 고유 ID 부여
+            'author_initial': '김',
+            'title': '첫 번째 테스트 포스트입니다',
+            'author_name': '김테스트',
+            'created_at': now - datetime.timedelta(hours=2),
+            'content': '이것은 상세 페이지 내용입니다.\n\n줄바꿈이 잘 적용되는지 확인해보세요.\n상세 페이지 디자인이 아주 깔끔하게 나왔으면 좋겠네요.',
+            'snippet': '이것은 뷰에서 넘어온 가짜 데이터입니다. 루프가 잘 도는지 확인해보세요...',
+            'likes_count': 12,
+            'comments_count': 2, # 아래 더미 댓글 개수와 맞춤
+            'views': 150,
+            'is_liked': False, # 내가 좋아요 눌렀는지 여부
+        },
+        {
+            'id': 2,
+            'author_initial': '이',
+            'title': '두 번째 테스트: 월세 계약 시 주의사항',
+            'author_name': '이장고',
+            'created_at': now - datetime.timedelta(days=1),
+            'content': '월세 계약할 때 등기부등본 꼭 확인하세요.\n근저당이 너무 많이 잡혀있으면 위험합니다.\n\n1. 등기부등본 확인\n2. 집주인 신분증 확인\n3. 특약사항 꼼꼼히 넣기',
+            'snippet': '두 번째 가짜 데이터입니다. 둥근 모서리 카드 스타일이 잘 나오는지 확인합니다.',
+            'likes_count': 5,
+            'comments_count': 0,
+            'views': 42,
+            'is_liked': True, 
+        }
+    ]
+
+
+# Forms
 #TODO: 추후 Post 모델 만들고 ModelForm으로 교체하기
 class PostForm(forms.Form):
     title = forms.CharField(label='제목', max_length=200)
@@ -69,40 +108,67 @@ class CitizenView(TemplateView):
     template_name = "citizen.html"
 
 
+
 class CommunityView(TemplateView):
-    template_name = "community.html"
+    template_name = "community/community.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        #TODO : [DB 연동] Post 모델 완성 후, 아래 임시 데이터를 실제 DB 쿼리로 교체하기
-        #       현재는 Frontend UI확인을 위한 Mock 데이터입니다
-
-        dummy_posts = [
-            {
-                'author_initial': '김',
-                'detail_url': '#', # 실제로는 상세 페이지 URL
-                'title': '첫 번째 테스트 포스트입니다',
-                'author_name': '김테스트',
-                'created_at': datetime.datetime.now() - datetime.timedelta(hours=2), # 2시간 전
-                'snippet': '이것은 뷰에서 넘어온 가짜 데이터입니다. 루프가 잘 도는지 확인해보세요. 스타일이 잘 적용되었나요?',
-                'likes_count': 12,
-                'comments_count': 8,
-            },
-            {
-                'author_initial': '이',
-                'detail_url': '#',
-                'title': '두 번째 테스트: 월세 계약 시 주의사항',
-                'author_name': '이장고',
-                'created_at': datetime.datetime.now() - datetime.timedelta(days=1), # 1일 전
-                'snippet': '두 번째 가짜 데이터입니다. 둥근 모서리 카드 스타일이 잘 나오는지 확인합니다.',
-                'likes_count': 5,
-                'comments_count': 3,
-            }
-        ]
-
-        context['posts'] = dummy_posts
+        # 전역 함수에서 데이터 가져오기
+        posts = get_dummy_db()
+        
+        # 각 포스트에 상세 페이지 URL 연결 (하드코딩 방식)
+        # 나중에 urls.py 설정에 따라 '/community/1/' 등으로 자동 생성해야 함
+        for post in posts:
+            # {% url 'frontend:post_detail' post.id %} 와 같은 효과를 내기 위해 
+            # 템플릿에서 처리하도록 여기서는 id만 잘 넘겨주기
+            post['detail_url'] = f"/community/{post['id']}/" 
+            
+        context['posts'] = posts
         return context
+    
+
+# 상세 페이지 뷰
+def post_detail_view(request, post_id):
+    # 1. 전체 더미 데이터 가져오기
+    posts = get_dummy_db()
+    
+    # 2. 요청된 post_id와 일치하는 데이터 찾기
+    # (Python 리스트에서 검색)
+    target_post = None
+    for post in posts:
+        if post['id'] == post_id:
+            target_post = post
+            break
+    
+    # 3. 없으면 404 에러
+    if target_post is None:
+        raise Http404("게시글을 찾을 수 없습니다.")
+
+    # 4. 더미 댓글 데이터 생성 (상세 페이지용)
+    dummy_comments = [
+        {
+            'author_initial': '박',
+            'author_name': '박댓글',
+            'created_at': datetime.datetime.now(),
+            'content': '정말 유용한 정보네요! 감사합니다.'
+        },
+        {
+            'author_initial': 'Guest',
+            'author_name': '지나가던행인',
+            'created_at': datetime.datetime.now() - datetime.timedelta(minutes=30),
+            'content': '디자인이 깔끔해서 보기 좋아요.'
+        }
+    ]
+
+    context = {
+        'post': target_post,
+        'comments': dummy_comments if target_post['id'] == 1 else [], # 1번 글에만 댓글이 있다고 가정
+    }
+    
+    return render(request, 'community/post_detail.html', context)
+
     
 class EmotionalView(TemplateView):
     template_name = "emotional.html"


### PR DESCRIPTION
## PR 내용
https://github.com/user-attachments/assets/e75f82fd-472d-4fbe-ab03-adecc6b1c921


## 기타 할 말, 요구사항
> 커뮤니티 페이지에서 게시글 누르거나 댓글 눌렀을 때 상세페이지로 넘어가도록 구현해놨습니다!
> 로그인 없이도 게시글과 댓글은 볼 수 있지만, 댓글작성을 위해서는 로그인이 필요하도록(로그인 페이지로 넘어가도록) 만들었습니다.
> 다만 좋아요는 커뮤니티 페이지와 상세페이지 두 곳에서 누를 수 있도록 만들어 두었기에 이는 수정이 필요합니다. -> 상세페이지에서만 누를 수 있으며, 로그인이 되어있지 않은 상황에서는 로그인 페이지로 넘어갈 수 있게끔 수정하기